### PR TITLE
Use short URL for png link

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 <meta name="description" content="San Francisco bae color palette. Welcome to the bae.">
 <meta name="theme-color" content="#bae">
 
-<!-- images via https://github.com/s9a/bae/issues/5 -->
+<!-- https://git.io/bae_png -->
 <meta property="og:image" content="https://user-images.githubusercontent.com/949985/46566589-3e628280-c8d6-11e8-8492-3c3fceb6ac60.png">
 <meta property="og:image:alt" content="#bae">
 <meta property="og:image" content="https://user-images.githubusercontent.com/949985/46566565-dca21880-c8d5-11e8-8b82-677cec7a116c.png">


### PR DESCRIPTION
### use https://git.io/bae_png short URL made for #5

```
curl -i https://git.io -F "url=https://github.com/s9a/bae/issues/5" -F "code=bae_png"
```

> HTTP/1.1 201 Created
> Server: Cowboy
> Connection: keep-alive
> Date: Tue, 23 Oct 2018 12:07:08 GMT
> Status: 201 Created
> Content-Type: text/html;charset=utf-8
> Location: https://git.io/bae_png
> Content-Length: 35
> X-Xss-Protection: 1; mode=block
> X-Content-Type-Options: nosniff
> X-Frame-Options: SAMEORIGIN
> X-Runtime: 0.094257
> X-Node: baac46f9-21c6-4f02-aed1-29338b90777e
> X-Revision: 392798d237fc1aa5cd55cada10d2945773e741a8
> Strict-Transport-Security: max-age=31536000; includeSubDomains
> Via: 1.1 vegur
>
> `https://github.com/s9a/bae/issues/5`