### PR TITLE
Try vein and vine colors

### DIFF
--- a/bae.css
+++ b/bae.css
@@ -28,3 +28,13 @@
   color: #bae !important;
   background: #510 !important;
 }
+
+.bae-vine {
+  color: #707 !important;
+  background: #4ea !important;
+}
+
+.bae-vein {
+  color: #4ea !important;
+  background: #707 !important;
+}


### PR DESCRIPTION
`#4ea` is because it's like bae4ya and sounds like flora. Originally I was thinking to pair that with `#415`  but went here with `#707` like Napa's area code. TBD documenting but I'll merge once as is so that it can be tried via chrome devtools on [the poster](https://s9a.github.io/bae/) and open to changing

- [`#415` makes `9.64` contrast ratio](https://contrast-ratio.com/#%234ea-on-%23415)
- [`#707` makes `6.85` contrast ratio](https://contrast-ratio.com/#%234ea-on-%23707)

