### PR TITLE
shortcut isn't rel

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
 <meta property="og:image" content="https://user-images.githubusercontent.com/949985/47357987-457ee400-d67d-11e8-8a51-b38102c7b21c.png">
 <meta property="og:image:alt" content="#bae : #510">
 
-<link rel="shortcut icon" href="https://user-images.githubusercontent.com/949985/46566589-3e628280-c8d6-11e8-8492-3c3fceb6ac60.png">
+<link rel="icon" href="https://user-images.githubusercontent.com/949985/46566589-3e628280-c8d6-11e8-8492-3c3fceb6ac60.png">
 <link rel="stylesheet" href="bae.css">
 <link rel="stylesheet" href="demo.css">
 


### PR DESCRIPTION
[MDN says](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel) `shortcut` is ignored and recommends only `icon` for favicon

~`rel="shortcut icon"`~ `rel="icon"`